### PR TITLE
add rubocop-legion plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     uses: LegionIO/.github/.github/workflows/ci.yml@main
 
-  lint:
-    uses: LegionIO/.github/.github/workflows/lint-patterns.yml@main
+  excluded-files:
+    uses: LegionIO/.github/.github/workflows/excluded-files.yml@main
 
   security:
     uses: LegionIO/.github/.github/workflows/security-scan.yml@main
@@ -27,7 +27,7 @@ jobs:
     uses: LegionIO/.github/.github/workflows/stale.yml@main
 
   release:
-    needs: [ci, lint]
+    needs: [ci, excluded-files]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: LegionIO/.github/.github/workflows/release.yml@main
     secrets:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,48 +1,5 @@
-AllCops:
-  TargetRubyVersion: 3.4
-  NewCops: enable
-  SuggestExtensions: false
+inherit_gem:
+  rubocop-legion: config/lex.yml
 
-Layout/LineLength:
-  Max: 160
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: space
-
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
-
-Metrics/MethodLength:
-  Max: 50
-
-Metrics/ClassLength:
-  Max: 1500
-
-Metrics/ModuleLength:
-  Max: 1500
-
-Metrics/BlockLength:
-  Max: 40
-
-Metrics/AbcSize:
-  Max: 60
-
-Metrics/CyclomaticComplexity:
-  Max: 15
-
-Metrics/PerceivedComplexity:
-  Max: 17
-
-Style/Documentation:
-  Enabled: false
-
-Style/SymbolArray:
-  Enabled: true
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
-
-Naming/FileName:
+Legion/Extension/RunnerIncludeHelpers:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2] - 2026-03-30
+
+### Changed
+- update to rubocop-legion 0.1.7, resolve all offenses
+
 ## [0.2.1] - 2026-03-22
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'rubocop'
+  gem 'rubocop-legion', '~> 0.1'
   gem 'simplecov'
 end

--- a/lib/legion/extensions/s3.rb
+++ b/lib/legion/extensions/s3.rb
@@ -9,7 +9,7 @@ require 'legion/extensions/s3/client'
 module Legion
   module Extensions
     module S3
-      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core
+      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core, false
     end
   end
 end

--- a/lib/legion/extensions/s3/runners/buckets.rb
+++ b/lib/legion/extensions/s3/runners/buckets.rb
@@ -23,7 +23,7 @@ module Legion
           def bucket_exists?(bucket:, **)
             s3_client(**).head_bucket(bucket: bucket)
             { exists: true, bucket: bucket }
-          rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchBucket
+          rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchBucket => _e
             { exists: false, bucket: bucket }
           end
         end

--- a/lib/legion/extensions/s3/version.rb
+++ b/lib/legion/extensions/s3/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module S3
-      VERSION = '0.2.1'
+      VERSION = '0.2.2'
     end
   end
 end

--- a/spec/legion/extensions/s3/client_spec.rb
+++ b/spec/legion/extensions/s3/client_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Legion::Extensions::S3::Client do # rubocop:disable Metrics/BlockLength
+RSpec.describe Legion::Extensions::S3::Client do
   let(:mock_s3) { double('Aws::S3::Client') }
 
   before do


### PR DESCRIPTION
## Summary
- Add rubocop-legion 0.1.7 with shared lex.yml config profile
- Replace inline .rubocop.yml with inherit_gem directive
- Update CI workflow to use excluded-files check
- Fix all rubocop offenses

## Test plan
- [ ] CI passes (rspec + rubocop)